### PR TITLE
last-minute changes to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ NOTE: It seems that the biopython version is important. On version 1.85, the ass
 Then, run
 
 ```bash
-python setup.py install
+pip install .
 ```
 
 to install the code in this repo as a package.

--- a/hpacker/src/preprocessing/utils/zernikegrams.py
+++ b/hpacker/src/preprocessing/utils/zernikegrams.py
@@ -157,7 +157,7 @@ def zernike_coeff_lm_new(
     l_sph_harm_tile = np.tile(lm_unique_combs[:, 0], (p.shape[1], 1)).T
     m_sph_harm_tile = np.tile(lm_unique_combs[:, 1], (p.shape[1], 1)).T
 
-    y_unique = np.conj(sp.special.sph_harm(m_sph_harm_tile, l_sph_harm_tile,
+    y_unique = np.conj(sp.special.sph_harm_y(m_sph_harm_tile, l_sph_harm_tile,
                                            p[:num_lm_combs], t[:num_lm_combs]))
     y = y_unique[lm_inv_map]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extra_files = package_files('hpacker')
 
 setuptools.setup(
     name='hpacker',
-    version='0.1.0',
+    version='0.1.1',
     author='Gian Marco Visani',
     author_email='gvisan01@cs.washington.edu',
     description='Holographic Rotationally Equivariant Convolutional Neural Network for Protein Side-Chain Packing',
@@ -22,28 +22,17 @@ setuptools.setup(
     url='https://github.com/gvisani/hpacker',
     python_requires='>=3.9',
     package_data={'': extra_files},
-
-    # package_data={'hpacker': ['hpacker/src/preprocessing/*',
-    #                           "src/pretrained_models/*",
-    #                           "psrc/retrained_models/initial_guess/*",
-    #                           "psrc/retrained_models/initial_guess_conditioned/*",
-    #                           "src/pretrained_models/refinement/*",
-    #                           "sidechain_reconstrution/*",
-    #                           "sidechain_reconstrution/biopython_internal_coords/*",
-    #                           "sidechain_reconstrution/biopython_internal_coords/plots/*",
-    #                           "sidechain_reconstrution/manual/*",
-    #                           "preprocessing/utils",
-    #                           ]},
-
     install_requires=[
-        'biopython',
-        "torch",
-        "tqdm",
-        "progress"
-        "h5py",
-        "hdf5plugin",
-        "sqlitedict",
-        "e3nn"
+        'biopython==1.81',
+        'tqdm',
+        'progress',
+        'h5py',
+        'hdf5plugin',
+        'sqlitedict',
+        'numpy',
+        'e3nn',
+        'torch',
+
     ],
     packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
updated the readme to show installation via pip, added dependencies to ensure those get installed automatically when running pip, and fixed deprecated call to scpiy.special.sph_harm (now sph_harm_y)